### PR TITLE
feat(mcp): make componentSlug optional in searchUnitsWithFilters

### DIFF
--- a/.changeset/optional-component-search.md
+++ b/.changeset/optional-component-search.md
@@ -1,0 +1,14 @@
+---
+"@mmntm/weblate-mcp": minor
+---
+
+Make componentSlug optional in searchUnitsWithFilters
+
+The `componentSlug` parameter in the `searchUnitsWithFilters` tool is now optional. When omitted, the search will query translation units across all components in the specified project.
+
+**Changes:**
+- Updated `componentSlug` parameter from required to optional in tool schema
+- Modified search logic to skip component filter when `componentSlug` is not provided
+- Updated all result messages to reflect whether component scope is applied
+
+This enhancement enables more flexible translation searches, allowing users to find strings across entire projects without specifying individual components.

--- a/src/services/weblate-api.service.ts
+++ b/src/services/weblate-api.service.ts
@@ -197,7 +197,7 @@ export class WeblateApiService {
 
   async searchUnitsWithQuery(
     projectSlug: string,
-    componentSlug: string,
+    componentSlug: string | undefined,
     languageCode: string,
     searchQuery: string,
     limit: number = 50,

--- a/src/services/weblate/translations.service.ts
+++ b/src/services/weblate/translations.service.ts
@@ -369,7 +369,7 @@ export class WeblateTranslationsService {
    */
   async searchUnitsWithQuery(
     projectSlug: string,
-    componentSlug: string,
+    componentSlug: string | undefined,
     languageCode: string,
     searchQuery: string,
     limit: number = 50,
@@ -380,7 +380,9 @@ export class WeblateTranslationsService {
       // Build the complete search query by combining user query with scope filters
       const queryParts = [searchQuery];
       queryParts.push(`project:${projectSlug}`);
-      queryParts.push(`component:${componentSlug}`);
+      if (componentSlug) {
+        queryParts.push(`component:${componentSlug}`);
+      }
       queryParts.push(`language:${languageCode}`);
       
       // Use the generated SDK with extended types to include the missing 'q' parameter
@@ -405,7 +407,7 @@ export class WeblateTranslationsService {
       return data.results || [];
     } catch (error) {
       this.logger.error(
-        `Failed to search units with query "${searchQuery}" in ${projectSlug}/${componentSlug}/${languageCode}`,
+        `Failed to search units with query "${searchQuery}" in ${projectSlug}/${componentSlug ?? '*'}/${languageCode}`,
         error,
       );
       throw new Error(

--- a/src/tools/translations.tool.ts
+++ b/src/tools/translations.tool.ts
@@ -382,7 +382,7 @@ export class WeblateTranslationsTool {
     description: 'Search translation units using Weblate\'s powerful filtering syntax. Supports filters like: state:<translated (untranslated), state:>=translated (translated), component:NAME, source:TEXT, target:TEXT, has:suggestion, etc.',
     parameters: z.object({
       projectSlug: z.string().describe('The slug of the project'),
-      componentSlug: z.string().describe('The slug of the component'),
+      componentSlug: z.string().optional().describe('The slug of the component (optional, omit to search across all components)'),
       languageCode: z.string().describe('The language code (e.g., sk, cs, fr)'),
       searchQuery: z.string().describe('Weblate search query using their filter syntax. Examples: "state:<translated" (untranslated), "state:>=translated" (translated), "source:hello", "has:suggestion", "component:common AND state:<translated"'),
       limit: z.number().optional().default(50).describe('Maximum number of results to return (default: 50, max: 200)'),
@@ -396,7 +396,7 @@ export class WeblateTranslationsTool {
     limit = 50,
   }: {
     projectSlug: string;
-    componentSlug: string;
+    componentSlug?: string;
     languageCode: string;
     searchQuery: string;
     limit?: number;
@@ -410,18 +410,20 @@ export class WeblateTranslationsTool {
         Math.min(limit, 200), // Cap at 200 to prevent overwhelming responses
       );
 
+      const scope = this.formatScope(componentSlug, projectSlug, languageCode);
+
       if (results.length === 0) {
         return {
           content: [
             {
               type: 'text',
-              text: `No units found matching query "${searchQuery}" in ${projectSlug}/${componentSlug}/${languageCode}`,
+              text: `No units found matching query "${searchQuery}" in ${scope}`,
             },
           ],
         };
       }
 
-      const resultText = this.formatFilteredResults(results, projectSlug, componentSlug, languageCode, searchQuery);
+      const resultText = this.formatFilteredResults(results, scope, searchQuery);
       
       return {
         content: [
@@ -469,9 +471,9 @@ export class WeblateTranslationsTool {
 **ID:** ${translation.id}`;
   }
 
-  private formatFilteredResults(results: Unit[], projectSlug: string, componentSlug: string, languageCode: string, searchQuery: string): string {
+  private formatFilteredResults(results: Unit[], scope: string, searchQuery: string): string {
     if (results.length === 0) {
-      return `No units found in ${projectSlug}/${componentSlug}/${languageCode} matching query: ${searchQuery}`;
+      return `No units found in ${scope} matching query: ${searchQuery}`;
     }
 
     const formattedResults = results
@@ -506,6 +508,10 @@ export class WeblateTranslationsTool {
       ? `\n\n*Showing first 50 of ${results.length} units*`
       : '';
 
-    return `Found ${results.length} units in ${projectSlug}/${componentSlug}/${languageCode} matching query "${searchQuery}":\n\n${formattedResults}${totalText}`;
+    return `Found ${results.length} units in ${scope} matching query "${searchQuery}":\n\n${formattedResults}${totalText}`;
+  }
+
+  private formatScope(componentSlug: string | undefined, projectSlug: string, languageCode: string): string {
+    return componentSlug ? `${projectSlug}/${componentSlug}/${languageCode}` : `${projectSlug}/*/${languageCode}`;
   }
 } 


### PR DESCRIPTION
Makes `componentSlug` an optional parameter in the `searchUnitsWithFilters` tool to allow searches across all components in a project.