### PR TITLE
feat: add createTranslationUnit MCP tool

### DIFF
--- a/.changeset/add-create-translation-unit.md
+++ b/.changeset/add-create-translation-unit.md
@@ -1,0 +1,5 @@
+---
+"@mmntm/weblate-mcp": minor
+---
+
+Add `createTranslationUnit` tool for creating new translation units (keys) in Weblate. Supports both monolingual formats (key + value) and bilingual formats (context + source + target).

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -41,6 +41,7 @@ Translation Management:
 - searchStringInProject: Search for translations containing specific text
 - getTranslationForKey: Get translation value for a specific key
 - writeTranslation: Write or update a translation value
+- createTranslationUnit: Create a new translation unit (key) - supports monolingual and bilingual formats
 - searchTranslationsByKey: Search for translations by key pattern
 - findTranslationsForKey: Find all translations for a specific key
 - listTranslationKeys: List all translation keys in a project

--- a/src/services/weblate-api.service.ts
+++ b/src/services/weblate-api.service.ts
@@ -210,4 +210,29 @@ export class WeblateApiService {
       limit,
     );
   }
+
+  /**
+   * Create a new translation unit in Weblate.
+   * Supports monolingual (key + value) and bilingual (context + source + target) formats.
+   */
+  async createTranslationUnit(
+    projectSlug: string,
+    componentSlug: string,
+    languageCode: string,
+    params: {
+      key?: string;
+      value?: string[];
+      context?: string;
+      source?: string[];
+      target?: string[];
+      state?: number;
+    },
+  ): Promise<Unit> {
+    return this.translationsService.createTranslationUnit(
+      projectSlug,
+      componentSlug,
+      languageCode,
+      params,
+    );
+  }
 }

--- a/src/services/weblate/translations.service.spec.ts
+++ b/src/services/weblate/translations.service.spec.ts
@@ -1,0 +1,150 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WeblateTranslationsService } from './translations.service';
+import { WeblateClientService } from '../weblate-client.service';
+import * as sdk from '../../client/sdk.gen';
+
+describe('WeblateTranslationsService', () => {
+  let service: WeblateTranslationsService;
+  let mockClient: any;
+
+  beforeEach(async () => {
+    mockClient = {};
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WeblateTranslationsService,
+        {
+          provide: WeblateClientService,
+          useValue: { getClient: jest.fn().mockReturnValue(mockClient) },
+        },
+      ],
+    }).compile();
+
+    service = module.get<WeblateTranslationsService>(
+      WeblateTranslationsService,
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('createTranslationUnit', () => {
+    it('should create a monolingual unit with key and value', async () => {
+      const mockUnit = {
+        id: 42,
+        context: '',
+        source: ['Hello'],
+        target: [],
+        web_url:
+          'https://weblate.example.com/translate/my-project/my-component/en/?checksum=abc123',
+      };
+
+      jest
+        .spyOn(sdk, 'translationsUnitsCreate')
+        .mockResolvedValue({ data: mockUnit, error: undefined } as any);
+
+      const result = await service.createTranslationUnit(
+        'my-project',
+        'my-component',
+        'en',
+        { key: 'greeting', value: ['Hello'] },
+      );
+
+      expect(result).toEqual(mockUnit);
+      expect(sdk.translationsUnitsCreate).toHaveBeenCalledWith({
+        client: mockClient,
+        path: {
+          component__project__slug: 'my-project',
+          component__slug: 'my-component',
+          language__code: 'en',
+        },
+        body: { key: 'greeting', value: ['Hello'] },
+      });
+    });
+
+    it('should create a bilingual unit with context, source, and target', async () => {
+      const mockUnit = {
+        id: 43,
+        context: 'greeting_message',
+        source: ['Hello'],
+        target: ['Hola'],
+        web_url:
+          'https://weblate.example.com/translate/my-project/my-component/es/?checksum=def456',
+      };
+
+      jest
+        .spyOn(sdk, 'translationsUnitsCreate')
+        .mockResolvedValue({ data: mockUnit, error: undefined } as any);
+
+      const result = await service.createTranslationUnit(
+        'my-project',
+        'my-component',
+        'es',
+        { context: 'greeting_message', source: ['Hello'], target: ['Hola'] },
+      );
+
+      expect(result).toEqual(mockUnit);
+      expect(sdk.translationsUnitsCreate).toHaveBeenCalledWith({
+        client: mockClient,
+        path: {
+          component__project__slug: 'my-project',
+          component__slug: 'my-component',
+          language__code: 'es',
+        },
+        body: {
+          context: 'greeting_message',
+          source: ['Hello'],
+          target: ['Hola'],
+        },
+      });
+    });
+
+    it('should pass state parameter when provided', async () => {
+      const mockUnit = { id: 44, context: '', source: ['Hi'], target: [] };
+
+      jest
+        .spyOn(sdk, 'translationsUnitsCreate')
+        .mockResolvedValue({ data: mockUnit, error: undefined } as any);
+
+      await service.createTranslationUnit('proj', 'comp', 'en', {
+        key: 'hi',
+        value: ['Hi'],
+        state: 20,
+      });
+
+      expect(sdk.translationsUnitsCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: { key: 'hi', value: ['Hi'], state: 20 },
+        }),
+      );
+    });
+
+    it('should throw on API error response', async () => {
+      jest.spyOn(sdk, 'translationsUnitsCreate').mockResolvedValue({
+        data: undefined,
+        error: { detail: 'Not found' },
+      } as any);
+
+      await expect(
+        service.createTranslationUnit('proj', 'comp', 'en', {
+          key: 'test',
+          value: ['Test'],
+        }),
+      ).rejects.toThrow('Failed to create translation unit');
+    });
+
+    it('should throw on network error', async () => {
+      jest
+        .spyOn(sdk, 'translationsUnitsCreate')
+        .mockRejectedValue(new Error('Network error'));
+
+      await expect(
+        service.createTranslationUnit('proj', 'comp', 'en', {
+          key: 'test',
+          value: ['Test'],
+        }),
+      ).rejects.toThrow('Failed to create translation unit');
+    });
+  });
+});

--- a/src/services/weblate/translations.service.ts
+++ b/src/services/weblate/translations.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { WeblateClientService } from '../weblate-client.service';
-import { unitsList, unitsPartialUpdate, translationsUnitsRetrieve, type Unit, type PaginatedUnitList, type UnitsListData, type TranslationsUnitsRetrieveData } from '../../client';
+import { unitsList, unitsPartialUpdate, translationsUnitsRetrieve, translationsUnitsCreate, type Unit, type PaginatedUnitList, type UnitsListData, type TranslationsUnitsRetrieveData, type TranslationsUnitsCreateData } from '../../client';
 import { SearchIn } from '../../types';
 
 @Injectable()
@@ -533,4 +533,55 @@ export class WeblateTranslationsService {
     
     return parts;
   }
-} 
+
+  /**
+   * Create a new translation unit in Weblate.
+   * Supports monolingual (key + value) and bilingual (context + source + target) formats.
+   */
+  async createTranslationUnit(
+    projectSlug: string,
+    componentSlug: string,
+    languageCode: string,
+    params: {
+      key?: string;
+      value?: string[];
+      context?: string;
+      source?: string[];
+      target?: string[];
+      state?: number;
+    },
+  ): Promise<Unit> {
+    try {
+      const client = this.weblateClientService.getClient();
+
+      // The generated SDK types model the body as `Translation`, but the
+      // Weblate unit creation endpoint accepts a subset of unit fields
+      // (key/value for monolingual, context/source/target for bilingual).
+      // Cast to work around inaccurate generated types.
+      const response = await translationsUnitsCreate({
+        client,
+        path: {
+          component__project__slug: projectSlug,
+          component__slug: componentSlug,
+          language__code: languageCode,
+        },
+        body: params as TranslationsUnitsCreateData['body'],
+      });
+
+      if (response.error) {
+        throw new Error(`API error: ${JSON.stringify(response.error)}`);
+      }
+
+      // Response is a Unit, not a Translation as the SDK declares
+      return response.data as unknown as Unit;
+    } catch (error) {
+      this.logger.error(
+        `Failed to create translation unit in ${projectSlug}/${componentSlug}/${languageCode}`,
+        error,
+      );
+      throw new Error(
+        `Failed to create translation unit: ${error.message}`,
+      );
+    }
+  }
+}

--- a/src/tools/translations.tool.ts
+++ b/src/tools/translations.tool.ts
@@ -445,6 +445,99 @@ export class WeblateTranslationsTool {
     }
   }
 
+  @Tool({
+    name: 'createTranslationUnit',
+    description:
+      'Create a new translation unit (key) in a Weblate translation. Use key+value for monolingual formats (JSON, Android) or context+source+target for bilingual formats (PO, XLIFF).',
+    parameters: z.object({
+      projectSlug: z.string().describe('The project URL slug'),
+      componentSlug: z.string().describe('The component URL slug'),
+      languageCode: z.string().describe('The translation language code'),
+      key: z
+        .string()
+        .optional()
+        .describe('Key for monolingual formats (JSON, Android)'),
+      value: z
+        .array(z.string())
+        .optional()
+        .describe(
+          'Array of strings — single element for regular, multiple for plural forms, e.g. ["Hello"]',
+        ),
+      context: z
+        .string()
+        .optional()
+        .describe('Context for bilingual formats (PO, XLIFF)'),
+      source: z
+        .array(z.string())
+        .optional()
+        .describe(
+          'Array of strings — single element for regular, multiple for plural forms, e.g. ["Hello"]',
+        ),
+      target: z
+        .array(z.string())
+        .optional()
+        .describe(
+          'Array of strings — single element for regular, multiple for plural forms, e.g. ["Hallo"]',
+        ),
+      state: z
+        .number()
+        .optional()
+        .describe(
+          'Unit state: 0=untranslated, 10=needs editing, 20=translated, 30=approved',
+        ),
+    }),
+  })
+  async createTranslationUnit({
+    projectSlug,
+    componentSlug,
+    languageCode,
+    key,
+    value,
+    context,
+    source,
+    target,
+    state,
+  }: {
+    projectSlug: string;
+    componentSlug: string;
+    languageCode: string;
+    key?: string;
+    value?: string[];
+    context?: string;
+    source?: string[];
+    target?: string[];
+    state?: number;
+  }) {
+    try {
+      const unit = await this.weblateApiService.createTranslationUnit(
+        projectSlug,
+        componentSlug,
+        languageCode,
+        { key, value, context, source, target, state },
+      );
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Successfully created translation unit in ${projectSlug}/${componentSlug}/${languageCode}\n\n**ID:** ${unit.id}\n**Key/Context:** ${unit.context || key || '(none)'}\n**Source:** ${Array.isArray(unit.source) ? unit.source.join(', ') : unit.source}\n**web_url:** ${unit.web_url || '(not available)'}`,
+          },
+        ],
+      };
+    } catch (error) {
+      this.logger.error('Failed to create translation unit', error);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Error creating translation unit: ${error.message}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  }
+
   private formatTranslationResult(translation: Unit): string {
     const status = translation.approved
       ? '✅ Approved'


### PR DESCRIPTION
Add the ability to create new translation units (keys) in Weblate. Supports both monolingual formats (key + value) and bilingual formats (context + source + target) through a single unified tool.

- Service: createTranslationUnit() on WeblateTranslationsService
- Facade: delegation method on WeblateApiService
- Tool: @Tool() decorated MCP endpoint with Zod validation
- Tests: 5 unit tests for the service layer
- Changeset: minor version bump

Closes: #8 


Full disclosure: This was written with Claude. I ran the MCP locally and tested it with another project and it successfully created the translation unit in my weblate instance (monolingual XLIFF).