### PR TITLE
fix+feat(translations): fuzzy writes, fix unit search & baseURL, write-by-id tools

### DIFF
--- a/src/services/weblate-api.service.ts
+++ b/src/services/weblate-api.service.ts
@@ -96,6 +96,7 @@ export class WeblateApiService {
     key: string,
     value: string,
     markAsApproved: boolean = false,
+    markAsNeedsEditing: boolean = false,
   ): Promise<Unit | null> {
     return this.translationsService.writeTranslation(
       projectSlug,
@@ -104,6 +105,7 @@ export class WeblateApiService {
       key,
       value,
       markAsApproved,
+      markAsNeedsEditing,
     );
   }
 
@@ -115,6 +117,7 @@ export class WeblateApiService {
       key: string;
       value: string;
       markAsApproved?: boolean;
+      markAsNeedsEditing?: boolean;
     }>,
   ): Promise<{
     successful: Array<{ key: string; unit: Unit }>;
@@ -131,6 +134,29 @@ export class WeblateApiService {
       languageCode,
       translations,
     );
+  }
+
+  async writeTranslationById(
+    unitId: number | string,
+    value: string | string[],
+    options: { markAsApproved?: boolean; markAsNeedsEditing?: boolean } = {},
+  ): Promise<Unit | null> {
+    return this.translationsService.writeTranslationById(unitId, value, options);
+  }
+
+  async bulkWriteTranslationsById(
+    units: Array<{
+      id: number | string;
+      value: string | string[];
+      markAsApproved?: boolean;
+      markAsNeedsEditing?: boolean;
+    }>,
+  ): Promise<{
+    successful: Array<{ id: number | string; unit: Unit }>;
+    failed: Array<{ id: number | string; error: string }>;
+    summary: { total: number; successful: number; failed: number };
+  }> {
+    return this.translationsService.bulkWriteTranslationsById(units);
   }
 
   async searchTranslationKeys(

--- a/src/services/weblate-client.service.ts
+++ b/src/services/weblate-client.service.ts
@@ -17,8 +17,12 @@ export class WeblateClientService {
       );
     }
 
-    // Ensure the API URL ends with /api
-    const baseUrl = apiUrl.endsWith('/api') ? apiUrl : apiUrl + '/api';
+    // Normalize: strip trailing slashes, then ensure exactly one /api suffix.
+    // Avoids a broken double "//api" base URL when WEBLATE_API_URL is given
+    // with a trailing slash (e.g. "https://host/api/"), which makes every
+    // request 404 against the web UI instead of the REST API.
+    const trimmed = apiUrl.replace(/\/+$/, '');
+    const baseUrl = trimmed.endsWith('/api') ? trimmed : `${trimmed}/api`;
 
     this.client = createClient({
       baseUrl,

--- a/src/services/weblate/translations.service.ts
+++ b/src/services/weblate/translations.service.ts
@@ -162,6 +162,7 @@ export class WeblateTranslationsService {
     key: string,
     value: string,
     markAsApproved: boolean = false,
+    markAsNeedsEditing: boolean = false,
   ): Promise<Unit | null> {
     try {
       // First, find the translation unit by key
@@ -187,7 +188,7 @@ export class WeblateTranslationsService {
         path: { id: unit.id.toString() },
         body: {
           target: targetArray, // Properly parsed plural forms
-          state: markAsApproved ? 30 : 20, // 30 = approved, 20 = translated
+          state: markAsNeedsEditing ? 10 : markAsApproved ? 30 : 20, // 10 = needs editing (fuzzy), 20 = translated, 30 = approved
         },
       });
 
@@ -211,6 +212,7 @@ export class WeblateTranslationsService {
       key: string;
       value: string;
       markAsApproved?: boolean;
+      markAsNeedsEditing?: boolean;
     }>,
   ): Promise<{
     successful: Array<{ key: string; unit: Unit }>;
@@ -234,7 +236,7 @@ export class WeblateTranslationsService {
     }
 
     for (const chunk of chunks) {
-      const promises = chunk.map(async ({ key, value, markAsApproved = false }) => {
+      const promises = chunk.map(async ({ key, value, markAsApproved = false, markAsNeedsEditing = false }) => {
         try {
           const updatedUnit = await this.writeTranslation(
             projectSlug,
@@ -243,6 +245,7 @@ export class WeblateTranslationsService {
             key,
             value,
             markAsApproved,
+            markAsNeedsEditing,
           );
 
           if (updatedUnit) {
@@ -274,6 +277,100 @@ export class WeblateTranslationsService {
       failed,
       summary,
     };
+  }
+
+  /**
+   * Write a translation directly by unit id (no key lookup). Faster and
+   * unambiguous for batch operations where unit ids are already known
+   * (e.g. from searchUnitsWithQuery). `value` may be a string or, for plural
+   * languages, a pre-split array of plural forms.
+   */
+  async writeTranslationById(
+    unitId: number | string,
+    value: string | string[],
+    options: { markAsApproved?: boolean; markAsNeedsEditing?: boolean } = {},
+  ): Promise<Unit | null> {
+    const { markAsApproved = false, markAsNeedsEditing = false } = options;
+    try {
+      const client = this.weblateClientService.getClient();
+      const targetArray = Array.isArray(value) ? value : [value];
+
+      const response = await unitsPartialUpdate({
+        client,
+        path: { id: unitId.toString() },
+        body: {
+          target: targetArray,
+          state: markAsNeedsEditing ? 10 : markAsApproved ? 30 : 20, // 10 = needs editing (fuzzy), 20 = translated, 30 = approved
+        },
+      });
+
+      return response.data as Unit;
+    } catch (error) {
+      this.logger.error(`Failed to write translation for unit ${unitId}`, error);
+      throw new Error(
+        `Failed to write translation for unit ${unitId}: ${error.message}`,
+      );
+    }
+  }
+
+  /**
+   * Bulk-write translations by unit id with bounded concurrency. Each item is
+   * { id, value, markAsApproved?, markAsNeedsEditing? }.
+   */
+  async bulkWriteTranslationsById(
+    units: Array<{
+      id: number | string;
+      value: string | string[];
+      markAsApproved?: boolean;
+      markAsNeedsEditing?: boolean;
+    }>,
+  ): Promise<{
+    successful: Array<{ id: number | string; unit: Unit }>;
+    failed: Array<{ id: number | string; error: string }>;
+    summary: { total: number; successful: number; failed: number };
+  }> {
+    const successful: Array<{ id: number | string; unit: Unit }> = [];
+    const failed: Array<{ id: number | string; error: string }> = [];
+
+    this.logger.log(`Starting bulk update of ${units.length} units by id`);
+
+    const concurrencyLimit = 5;
+    const chunks = [];
+    for (let i = 0; i < units.length; i += concurrencyLimit) {
+      chunks.push(units.slice(i, i + concurrencyLimit));
+    }
+
+    for (const chunk of chunks) {
+      const promises = chunk.map(
+        async ({ id, value, markAsApproved = false, markAsNeedsEditing = false }) => {
+          try {
+            const unit = await this.writeTranslationById(id, value, {
+              markAsApproved,
+              markAsNeedsEditing,
+            });
+            if (unit) {
+              successful.push({ id, unit });
+            } else {
+              failed.push({ id, error: 'No unit returned from update' });
+            }
+          } catch (error) {
+            failed.push({ id, error: error.message });
+            this.logger.warn(`Failed to update unit ${id}: ${error.message}`);
+          }
+        },
+      );
+      await Promise.allSettled(promises);
+    }
+
+    const summary = {
+      total: units.length,
+      successful: successful.length,
+      failed: failed.length,
+    };
+
+    this.logger.log(`Bulk-by-id update completed: ${summary.successful}/${summary.total} successful, ${summary.failed} failed`);
+
+    return { successful, failed, summary };
   }
 
   async findTranslationsForKey(
@@ -377,13 +474,14 @@ export class WeblateTranslationsService {
     try {
       const client = this.weblateClientService.getClient();
       
-      // Build the complete search query by combining user query with scope filters
+      // Query the translation-scoped units endpoint (project/component/language as
+      // Build the combined query: user filter + project/component/language scope.
       const queryParts = [searchQuery];
       queryParts.push(`project:${projectSlug}`);
       queryParts.push(`component:${componentSlug}`);
       queryParts.push(`language:${languageCode}`);
-      
-      // Use the generated SDK with extended types to include the missing 'q' parameter
+
+      // Use the generated SDK with extended types to include the missing 'q' param.
       const options: UnitsListData & { query?: { q?: string; page_size?: number } } = {
         url: '/units/',
         query: {
@@ -396,11 +494,11 @@ export class WeblateTranslationsService {
         client,
         ...options,
       });
-      
+
       if (response.error) {
         throw new Error(`API error: ${JSON.stringify(response.error)}`);
       }
-      
+
       const data = response.data as PaginatedUnitList;
       return data.results || [];
     } catch (error) {

--- a/src/tools/translations.tool.ts
+++ b/src/tools/translations.tool.ts
@@ -161,6 +161,11 @@ export class WeblateTranslationsTool {
         .optional()
         .describe('Whether to mark as approved (default: false)')
         .default(false),
+      markAsNeedsEditing: z
+        .boolean()
+        .optional()
+        .describe('Mark as "Needs editing" (fuzzy, Weblate state 10) for review. Takes precedence over markAsApproved.')
+        .default(false),
     }),
   })
   async writeTranslation({
@@ -170,6 +175,7 @@ export class WeblateTranslationsTool {
     key,
     value,
     markAsApproved = false,
+    markAsNeedsEditing = false,
   }: {
     projectSlug: string;
     componentSlug: string;
@@ -177,6 +183,7 @@ export class WeblateTranslationsTool {
     key: string;
     value: string;
     markAsApproved?: boolean;
+    markAsNeedsEditing?: boolean;
   }) {
     try {
       const updatedUnit = await this.weblateApiService.writeTranslation(
@@ -186,6 +193,7 @@ export class WeblateTranslationsTool {
         key,
         value,
         markAsApproved,
+        markAsNeedsEditing,
       );
 
       return {
@@ -223,6 +231,7 @@ export class WeblateTranslationsTool {
         key: z.string().describe('The translation key to update'),
         value: z.string().describe('The new translation value'),
         markAsApproved: z.boolean().optional().describe('Whether to mark as approved (default: false)').default(false),
+        markAsNeedsEditing: z.boolean().optional().describe('Mark as "Needs editing" (fuzzy, state 10). Takes precedence over markAsApproved.').default(false),
       })).describe('Array of translations to update'),
     }),
   })
@@ -239,6 +248,7 @@ export class WeblateTranslationsTool {
       key: string;
       value: string;
       markAsApproved?: boolean;
+      markAsNeedsEditing?: boolean;
     }>;
   }) {
     try {
@@ -294,6 +304,94 @@ export class WeblateTranslationsTool {
             text: `Error during bulk translation update: ${error.message}`,
           },
         ],
+        isError: true,
+      };
+    }
+  }
+
+  @Tool({
+    name: 'writeTranslationById',
+    description: 'Write/update a translation directly by its numeric unit id (no key lookup). Use ids returned by searchUnitsWithFilters. Set markAsNeedsEditing to save as fuzzy ("Needs editing") for review.',
+    parameters: z.object({
+      unitId: z.union([z.number(), z.string()]).describe('The numeric unit id to update'),
+      value: z.string().describe('The new translation value'),
+      markAsApproved: z.boolean().optional().describe('Mark as approved (state 30, default: false)').default(false),
+      markAsNeedsEditing: z.boolean().optional().describe('Mark as "Needs editing" (fuzzy, state 10). Takes precedence over markAsApproved.').default(false),
+    }),
+  })
+  async writeTranslationById({
+    unitId,
+    value,
+    markAsApproved = false,
+    markAsNeedsEditing = false,
+  }: {
+    unitId: number | string;
+    value: string;
+    markAsApproved?: boolean;
+    markAsNeedsEditing?: boolean;
+  }) {
+    try {
+      const updatedUnit = await this.weblateApiService.writeTranslationById(unitId, value, {
+        markAsApproved,
+        markAsNeedsEditing,
+      });
+      return {
+        content: [
+          {
+            type: 'text',
+            text: updatedUnit
+              ? `Successfully updated unit ${unitId}\n\n${this.formatTranslationResult(updatedUnit)}`
+              : `Failed to update unit ${unitId}`,
+          },
+        ],
+      };
+    } catch (error) {
+      this.logger.error(`Failed to write translation for unit ${unitId}`, error);
+      return {
+        content: [{ type: 'text', text: `Error writing translation for unit ${unitId}: ${error.message}` }],
+        isError: true,
+      };
+    }
+  }
+
+  @Tool({
+    name: 'bulkWriteTranslationsById',
+    description: 'Bulk write/update translations by numeric unit id. Efficient for large batches where ids are already known (from searchUnitsWithFilters). Supports per-item markAsNeedsEditing (fuzzy).',
+    parameters: z.object({
+      units: z.array(z.object({
+        id: z.union([z.number(), z.string()]).describe('The numeric unit id'),
+        value: z.string().describe('The new translation value'),
+        markAsApproved: z.boolean().optional().describe('Mark as approved (state 30)').default(false),
+        markAsNeedsEditing: z.boolean().optional().describe('Mark as "Needs editing" (fuzzy, state 10). Takes precedence over markAsApproved.').default(false),
+      })).describe('Array of units to update by id'),
+    }),
+  })
+  async bulkWriteTranslationsById({
+    units,
+  }: {
+    units: Array<{ id: number | string; value: string; markAsApproved?: boolean; markAsNeedsEditing?: boolean }>;
+  }) {
+    try {
+      const result = await this.weblateApiService.bulkWriteTranslationsById(units);
+      let resultText = `Bulk update by id completed\n\n`;
+      resultText += `📊 **Summary:**\n`;
+      resultText += `- Total: ${result.summary.total}\n`;
+      resultText += `- ✅ Successful: ${result.summary.successful}\n`;
+      resultText += `- ❌ Failed: ${result.summary.failed}\n`;
+      if (result.failed.length > 0) {
+        resultText += `\n❌ **Failed (${result.failed.length}):**\n`;
+        result.failed.slice(0, 10).forEach(({ id, error }) => {
+          resultText += `- ${id}: ${error}\n`;
+        });
+        if (result.failed.length > 10) {
+          resultText += `... and ${result.failed.length - 10} more failures\n`;
+        }
+      }
+      return { content: [{ type: 'text', text: resultText }] };
+    } catch (error) {
+      this.logger.error(`Failed to bulk write translations by id`, error);
+      return {
+        content: [{ type: 'text', text: `Error during bulk update by id: ${error.message}` }],
         isError: true,
       };
     }


### PR DESCRIPTION
Fixes + features for the translation tooling, verified against a live Weblate (2026.x).

## Fixes
1. **baseURL normalization (root cause)** — `WEBLATE_API_URL` with a trailing slash (e.g. `.../api/`) produced a broken `//api` base URL that made every request 404 against the web UI. Trailing slashes are now stripped before appending `/api`. This alone fixes `searchUnitsWithFilters` (the global `/units/?q=...` search works once the base URL is correct — verified).
2. **fuzzy on write** — `writeTranslation` / `bulkWriteTranslations` gained `markAsNeedsEditing` (saves unit with state 10 = Needs editing); the facade forwards it. Lets clients submit machine/AI translations for human review.

## Features
3. **writeTranslationById** / **bulkWriteTranslationsById** — update units directly by numeric id (from `searchUnitsWithFilters`) without a key lookup; fast/unambiguous for batch work. Both support `markAsNeedsEditing`.

Compatible with #12 (optional componentSlug) since search keeps using the global `/units/` endpoint. Verified end-to-end with a trailing-slash URL: search returns units; write-by-id sets state 10/20; bulk-by-id ok.